### PR TITLE
adds mat file containing string to BpodUserPath in Bpod home directory

### DIFF
--- a/Functions/Internal Functions/BpodObject.m
+++ b/Functions/Internal Functions/BpodObject.m
@@ -118,13 +118,19 @@ classdef BpodObject < handle
             
             obj.HostOS = system_dependent('getos');
             obj.BpodPath = BpodPath;
-%% FS MOD
-            if ispc 
-                import java.lang.*;
-                obj.BpodUserPath = fullfile(char(System.getProperty('user.home')), 'BpodUser');
+            %% FS MOD
+            if exist(fullfile(obj.BpodPath,'BpodUserPath.mat'),'file')==2
+                load(fullfile(obj.BpodPath,'BpodUserPath.mat'));
             else
-                obj.BpodUserPath = fullfile('~', 'BpodUser');
+                if ispc
+                    import java.lang.*;
+                    BpodUserPath = fullfile(char(System.getProperty('user.home')), 'BpodUser');
+                else
+                    BpodUserPath = fullfile('~', 'BpodUser');
                 end
+                save(fullfile(obj.BpodPath,'BpodUserPath.mat'),'BpodUserPath')
+            end
+            obj.BpodUserPath = BpodUserPath;
             if ~isdir(obj.BpodUserPath)
                 mkdir(obj.BpodUserPath);
                 warning(['Bpod user directory not found. Directory created at ' obj.BpodUserPath]);

--- a/Functions/Internal Functions/BpodObject.m
+++ b/Functions/Internal Functions/BpodObject.m
@@ -119,8 +119,10 @@ classdef BpodObject < handle
             obj.HostOS = system_dependent('getos');
             obj.BpodPath = BpodPath;
             %% FS MOD
-            if exist(fullfile(obj.BpodPath,'BpodUserPath.mat'),'file')==2
-                load(fullfile(obj.BpodPath,'BpodUserPath.mat'));
+            if exist(fullfile(obj.BpodPath,'BpodUserPath.txt'),'file') == 2
+                UserFile = fopen(fullfile(obj.BpodPath,'BpodUserPath.txt'),'r');
+                BpodUserPath = fscanf(UserFile,'%s');
+                fclose(UserFile);
             else
                 if ispc
                     import java.lang.*;
@@ -128,7 +130,9 @@ classdef BpodObject < handle
                 else
                     BpodUserPath = fullfile('~', 'BpodUser');
                 end
-                save(fullfile(obj.BpodPath,'BpodUserPath.mat'),'BpodUserPath')
+                UserFile = fopen(fullfile(obj.BpodPath,'BpodUserPath.txt'),'w');
+                fprintf(UserFile,'%s',BpodUserPath);
+                fclose(UserFile);
             end
             obj.BpodUserPath = BpodUserPath;
             if ~isdir(obj.BpodUserPath)


### PR DESCRIPTION
Enables custom user folder for Data, Protocol, Settings Files, and Calibration Files. Related to #2 without button (seems to much right now) and #6 @fitzsturgill .

- in default mode, starting Bpod creates a mat (now txt, see below) file in Bpod home directory containing a single string storing the default user location (HOME/BpodUser)

- this txt file can be edited to an arbitrary directory which will be used at next Bpod startup

- Warning: Calibration Files and Settings Files will be copied from the Bpod home directory to new location ("resets" settings/calibrations). Old locations will not be deleted. Data and Protocols have to be copied manually, if wished (as before).

- only tested in Win10

Potential issue: There is a new custom file in Bpod directory. But I think there has to be one, could also be contained in a settings file, but then this setting file should remain in Bpod home directory. The current proposal is a simple fix which can be easily changed in the future if sanworks/Bpod changes the way it stores files and is keeping the bpod changes to a minium.