### PR TITLE
Save menu to Parameter GUI

### DIFF
--- a/Functions/Internal Functions/BpodObject.m
+++ b/Functions/Internal Functions/BpodObject.m
@@ -118,13 +118,19 @@ classdef BpodObject < handle
             
             obj.HostOS = system_dependent('getos');
             obj.BpodPath = BpodPath;
-%% FS MOD
-            if ispc 
-                import java.lang.*;
-                obj.BpodUserPath = fullfile(char(System.getProperty('user.home')), 'BpodUser');
+            %% FS MOD
+            if exist(fullfile(obj.BpodPath,'BpodUserPath.mat'),'file')==2
+                load(fullfile(obj.BpodPath,'BpodUserPath.mat'));
             else
-                obj.BpodUserPath = fullfile('~', 'BpodUser');
+                if ispc
+                    import java.lang.*;
+                    BpodUserPath = fullfile(char(System.getProperty('user.home')), 'BpodUser');
+                else
+                    BpodUserPath = fullfile('~', 'BpodUser');
                 end
+                save(fullfile(obj.BpodPath,'BpodUserPath.mat'),'BpodUserPath')
+            end
+            obj.BpodUserPath = BpodUserPath;
             if ~isdir(obj.BpodUserPath)
                 mkdir(obj.BpodUserPath);
                 warning(['Bpod user directory not found. Directory created at ' obj.BpodUserPath]);

--- a/Functions/Internal Functions/BpodObject.m
+++ b/Functions/Internal Functions/BpodObject.m
@@ -119,8 +119,10 @@ classdef BpodObject < handle
             obj.HostOS = system_dependent('getos');
             obj.BpodPath = BpodPath;
             %% FS MOD
-            if exist(fullfile(obj.BpodPath,'BpodUserPath.mat'),'file')==2
-                load(fullfile(obj.BpodPath,'BpodUserPath.mat'));
+            if exist(fullfile(obj.BpodPath,'BpodUserPath.txt'),'file') == 2
+                UserFile = fopen(fullfile(obj.BpodPath,'BpodUserPath.txt'),'r');
+                BpodUserPath = fscanf(UserFile,'%s');
+                fclose(UserFile);
             else
                 if ispc
                     import java.lang.*;
@@ -128,7 +130,9 @@ classdef BpodObject < handle
                 else
                     BpodUserPath = fullfile('~', 'BpodUser');
                 end
-                save(fullfile(obj.BpodPath,'BpodUserPath.mat'),'BpodUserPath')
+                UserFile = fopen(fullfile(obj.BpodPath,'BpodUserPath.txt'),'w');
+                fprintf(UserFile,'%s',BpodUserPath);
+                fclose(UserFile);
             end
             obj.BpodUserPath = BpodUserPath;
             if ~isdir(obj.BpodUserPath)

--- a/Functions/Plugins/ParameterGUI/BpodParameterGUI.m
+++ b/Functions/Plugins/ParameterGUI/BpodParameterGUI.m
@@ -271,5 +271,7 @@ global TaskParameters
 TaskParameters = BpodParameterGUI('sync', TaskParameters);
 ProtocolSettings = TaskParameters;
 [file,path] = uiputfile('*.mat','Select a Bpod ProtocolSettings file.',BpodSystem.SettingsPath);
-save(fullfile(path,file),'ProtocolSettings')
+if file>0
+    save(fullfile(path,file),'ProtocolSettings')
+end
 

--- a/Functions/Plugins/ParameterGUI/BpodParameterGUI.m
+++ b/Functions/Plugins/ParameterGUI/BpodParameterGUI.m
@@ -294,7 +294,7 @@ varargout{1} = Params;
 function SettingsMenuSave_Callback(~, ~, ~)
 global BpodSystem
 global TaskParameters
-ProtocolSettings = BpodParameterGUI('sync',TaskParameters);
+ProtocolSettings = BpodParameterGUI('get',TaskParameters);
 save(BpodSystem.SettingsPath,'ProtocolSettings')
 
 function SettingsMenuSaveAs_Callback(~, ~, SettingsMenuHandle)

--- a/Functions/Plugins/ParameterGUI/BpodParameterGUI.m
+++ b/Functions/Plugins/ParameterGUI/BpodParameterGUI.m
@@ -271,6 +271,7 @@ switch Op
                     Params.GUI.(ThisParamName) = GUIParam;
                 case 2 % Text
                     GUIParam = get(ThisParamHandle, 'String');
+                    GUIParam = str2double(GUIParam);  
                     Params.GUI.(ThisParamName) = GUIParam;
                 case 3 % Checkbox
                     GUIParam = get(ThisParamHandle, 'Value');
@@ -283,7 +284,10 @@ switch Op
                     Params.GUI.(ThisParamName) = GUIParam;
                 case 7 % Table
                     GUIParam = ThisParamHandle.Data;
-                    Params.GUI.(ThisParamName) = GUIParam;
+                    columnNames = fieldnames(Params.GUI.(ThisParamName));
+                    for iColumn = 1:numel(columnNames)
+                         Params.GUI.(ThisParamName).(columnNames{iColumn}) = GUIParam(:,iColumn);
+                    end
             end
         end
     otherwise

--- a/Functions/Plugins/ParameterGUI/BpodParameterGUI.m
+++ b/Functions/Plugins/ParameterGUI/BpodParameterGUI.m
@@ -71,6 +71,9 @@ switch Op
         ParamNum = 1;
         BpodSystem.ProtocolFigures.ParameterGUI = figure('Position', [50 50 450 GUIHeight],'name','Parameter GUI','numbertitle','off', 'MenuBar', 'none', 'Resize', 'on');
         BpodSystem.GUIHandles.ParameterGUI.Tabs.TabGroup = uitabgroup(BpodSystem.ProtocolFigures.ParameterGUI);
+        Menu = uimenu(BpodSystem.ProtocolFigures.ParameterGUI,'Label','File');
+        MenuSave = uimenu(Menu,'Label','Save','Callback',{@MenuSave_Callback});
+        MenuSaveAs = uimenu(Menu,'Label','Save as...','Callback',{@MenuSaveAs_Callback});
         for t = 1:nTabs
             VPos = 10;
             HPos = 10;
@@ -254,3 +257,19 @@ switch Op
     error('ParameterGUI must be called with a valid op code: ''init'' or ''sync''');
 end
 varargout{1} = Params;
+
+function MenuSave_Callback(hObject, eventdata, handles)
+global BpodSystem
+global TaskParameters
+TaskParameters = BpodParameterGUI('sync', TaskParameters);
+ProtocolSettings = TaskParameters;
+save(BpodSystem.SettingsPath,'ProtocolSettings')
+
+function MenuSaveAs_Callback(hObject, eventdata, handles)
+global BpodSystem
+global TaskParameters
+TaskParameters = BpodParameterGUI('sync', TaskParameters);
+ProtocolSettings = TaskParameters;
+[file,path] = uiputfile('*.mat','Select a Bpod ProtocolSettings file.',BpodSystem.SettingsPath);
+save(fullfile(path,file),'ProtocolSettings')
+

--- a/Functions/Plugins/ParameterGUI/BpodParameterGUI.m
+++ b/Functions/Plugins/ParameterGUI/BpodParameterGUI.m
@@ -71,15 +71,14 @@ switch Op
         ParamNum = 1;
         BpodSystem.ProtocolFigures.ParameterGUI = figure('Position', [50 50 450 GUIHeight],'name','Parameter GUI','numbertitle','off', 'MenuBar', 'none', 'Resize', 'on');
         BpodSystem.GUIHandles.ParameterGUI.Tabs.TabGroup = uitabgroup(BpodSystem.ProtocolFigures.ParameterGUI);
-        SettingsMenu = uimenu(BpodSystem.ProtocolFigures.ParameterGUI,'Label','Settings:');
         [~, SettingsFile] = fileparts(BpodSystem.SettingsPath);
-        SettingsNameMenu = uimenu(BpodSystem.ProtocolFigures.ParameterGUI,'Label',strcat(SettingsFile,'.'));
+        SettingsMenu = uimenu(BpodSystem.ProtocolFigures.ParameterGUI,'Label',['Settings: ',SettingsFile,'.']);
         uimenu(BpodSystem.ProtocolFigures.ParameterGUI,'Label',['Protocol: ', BpodSystem.CurrentProtocolName,'.']);
         [subpath1, ~] = fileparts(BpodSystem.DataPath); [subpath2, ~] = fileparts(subpath1); [subpath3, ~] = fileparts(subpath2);
         [~,  subject] = fileparts(subpath3);
         uimenu(BpodSystem.ProtocolFigures.ParameterGUI,'Label',['Subject: ', subject,'.']);
-        SettingsMenuSave = uimenu(SettingsMenu,'Label','Save','Callback',{@SettingsMenuSave_Callback});
-        SettingsMenuSaveAs = uimenu(SettingsMenu,'Label','Save as...','Callback',{@SettingsMenuSaveAs_Callback,SettingsNameMenu});
+        uimenu(SettingsMenu,'Label','Save','Callback',{@SettingsMenuSave_Callback});
+        uimenu(SettingsMenu,'Label','Save as...','Callback',{@SettingsMenuSaveAs_Callback,SettingsMenu});
         for t = 1:nTabs
             VPos = 10;
             HPos = 10;
@@ -307,6 +306,6 @@ if file>0
     save(fullfile(path,file),'ProtocolSettings')
     BpodSystem.SettingsPath = fullfile(path,file);
     [~,SettingsName] = fileparts(file);
-    set(SettingsMenuHandle,'Label',strcat(SettingsName,'.'));
+    set(SettingsMenuHandle,'Label',['Settings: ',SettingsName,'.']);
 end
 


### PR DESCRIPTION
Adds a "Settings" menu with "save" and "save as..." menu entries. "Save" stores current GUI Protocol Parameters to the currently used parameter file. "Save as..." saves to new Parameter file specified in save dialog. Solves #3.

**Changes**
- added menus to `BpodParameterGUI.m`
- added a 'get' option to `BpodParameterGUI.m`allowing for saving current parameters without syncing
- show current settings file used (this one will also be used when hitting "save") and current subject and protocol
