### PR TITLE
When stopping a Bpod protocol the custom user script UserKillScript.m…

### DIFF
--- a/Functions/Launch manager/RunProtocol.m
+++ b/Functions/Launch manager/RunProtocol.m
@@ -41,6 +41,12 @@ switch Opstring
             end
         end
     case 'Stop'
+        %execute user kill script
+        try
+            [~,Protocol]=fileparts(fileparts(fileparts(BpodSystem.DataPath)));
+            run(fullfile(BpodSystem.BpodUserPath,'Protocols',Protocol,'UserKillScript.m'));
+        catch
+        end
         if ~isempty(BpodSystem.CurrentProtocolName)
             disp(' ')
             disp([BpodSystem.CurrentProtocolName ' ended.'])


### PR DESCRIPTION
… located in the current protocol folder is executed, if it exists. Allows for custom actions at session end (eg email figures, etc).