### PR TITLE
added edit text/string option to parameter GUI

### DIFF
--- a/Functions/Plugins/ParameterGUI/BpodParameterGUI.m
+++ b/Functions/Plugins/ParameterGUI/BpodParameterGUI.m
@@ -126,6 +126,9 @@ switch Op
                         case 'edit'
                             BpodSystem.GUIData.ParameterGUI.Styles(ParamNum) = 1;
                             BpodSystem.GUIHandles.ParameterGUI.Params{ParamNum} = uicontrol(htab,'Style', 'edit', 'String', num2str(ThisParam), 'Position', [HPos+220 VPos+InPanelPos+2 200 25], 'FontWeight', 'normal', 'FontSize', 12, 'BackgroundColor','white', 'FontName', 'Arial','HorizontalAlignment','Center');
+                        case 'edittext'
+                            BpodSystem.GUIData.ParameterGUI.Styles(ParamNum) = 8;
+                            BpodSystem.GUIHandles.ParameterGUI.Params{ParamNum} = uicontrol(htab,'Style', 'edit', 'String', ThisParam, 'Position', [HPos+220 VPos+InPanelPos+2 200 25], 'FontWeight', 'normal', 'FontSize', 12, 'BackgroundColor','white', 'FontName', 'Arial','HorizontalAlignment','Center');
                         case 'text'
                             BpodSystem.GUIData.ParameterGUI.Styles(ParamNum) = 2;
                             BpodSystem.GUIHandles.ParameterGUI.Params{ParamNum} = uicontrol(htab,'Style', 'text', 'String', num2str(ThisParam), 'Position', [HPos+220 VPos+InPanelPos+2 200 25], 'FontWeight', 'normal', 'FontSize', 12, 'BackgroundColor','white', 'FontName', 'Arial','HorizontalAlignment','Center');
@@ -213,6 +216,13 @@ switch Op
                     elseif Params.GUI.(ThisParamName) ~= ThisParamLastValue
                         set(ThisParamHandle, 'String', num2str(GUIParam));
                     end
+                case 8 % Edit Text
+                    GUIParam = get(ThisParamHandle, 'String');
+                    if ~strcmpi(GUIParam, ThisParamLastValue)
+                        Params.GUI.(ThisParamName) = GUIParam;
+                    elseif ~strcmpi(Params.GUI.(ThisParamName), ThisParamLastValue)
+                        set(ThisParamHandle, 'String', GUIParam);
+                    end                                     
                 case 2 % Text
                     GUIParam = Params.GUI.(ThisParamName);
                     Text = GUIParam;
@@ -269,6 +279,9 @@ switch Op
                 case 1 % Edit
                     GUIParam = str2double(get(ThisParamHandle, 'String'));
                     Params.GUI.(ThisParamName) = GUIParam;
+                case 8 % Edit Text
+                    GUIParam = get(ThisParamHandle, 'String');
+                    Params.GUI.(ThisParamName) = GUIParam;                    
                 case 2 % Text
                     GUIParam = get(ThisParamHandle, 'String');
                     GUIParam = str2double(GUIParam);  

--- a/Functions/Plugins/Plots/TrialTypeOutcomePlot.m
+++ b/Functions/Plugins/Plots/TrialTypeOutcomePlot.m
@@ -64,6 +64,9 @@ switch Action
         end
         axes(AxesHandle);
         MaxTrialType = max(TrialTypeList);
+        if isnan(MaxTrialType)
+            MaxTrialType = 1; % for NaN filled TrialTypes, might occur if you determine trial type on the fly
+        end
         %plot in specified axes
         Xdata = 1:nTrialsToShow; Ydata = -TrialTypeList(Xdata);
         BpodSystem.GUIHandles.FutureTrialLine = line([Xdata,Xdata],[Ydata,Ydata],'LineStyle','none','Marker','o','MarkerEdge','b','MarkerFace','b', 'MarkerSize',6);
@@ -84,6 +87,9 @@ switch Action
         TrialTypeList = varargin{2};
         OutcomeRecord = varargin{3};
         MaxTrialType = max(TrialTypeList);
+        if isnan(MaxTrialType)
+            MaxTrialType = 1; % for NaN filled TrialTypes, might occur if you determine trial type on the fly
+        end
         set(AxesHandle,'YLim',[-MaxTrialType-.5, -.5], 'YTick', -MaxTrialType:1:-1,'YTickLabel', strsplit(num2str(MaxTrialType:-1:-1)));
         if CurrentTrial<1
             CurrentTrial = 1;


### PR DESCRIPTION
BpodParameterGUI:

Added 'edittext' option to supply and sync strings via Bpod parameter GUI.
ex.     S.GUI.stringParam = 'hello';
         S.GUIMeta.stringParam.Style = 'edittext'; % Edittext, editText also works, case insensitive

case insensitive
